### PR TITLE
window.activeTextEditor can be null

### DIFF
--- a/src/wiggin/codedox/CodeDox.hx
+++ b/src/wiggin/codedox/CodeDox.hx
@@ -260,7 +260,7 @@ class CodeDox
 			}
 
 			var editor = Vscode.window.activeTextEditor;
-			if(editor.document != doc)
+			if(editor == null || editor.document != doc)
 			{
 				return;
 			}


### PR DESCRIPTION
Encountered an error in the dev console because of the missing null check here.