### PR TITLE
Added support for .js and .vue files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     },
     "activationEvents": [
         "onLanguage:haxe",
+		"onLanguage:js",
+		"onLanguage:html",
         "onCommand:codedox.setup",
         "onCommand:codedox.fileheader.insert",
         "onCommand:codedox.comment.insert"

--- a/src/wiggin/codedox/Commenter.hx
+++ b/src/wiggin/codedox/Commenter.hx
@@ -155,16 +155,24 @@ class Commenter
 	 */
 	private static function getFunctionRegex(strLangaugeId:String) : EReg
 	{
-		var regex:EReg;
+		var haxe_regex:EReg;
+		var js_regex:EReg;
+
+		haxe_regex = ~/(?:function\s+\w+\s*)(?:<[\s\S]+>\s*)*\(([^)]*)\)(?:(?:(?:\s*:\s*)*(\w*[^{;]*)))/;
+		js_regex = ~/(?:function\s*\w*\s*)(?:<[\s\S]+>\s*)*\(([^)]*)\)(?:(?:(?:\s*:\s*)*(\w*[^{;]*)))/;
+
 		switch(strLangaugeId)
 		{
 			case "haxe":
-				regex = ~/(?:function\s+\w+\s*)(?:<[\s\S]+>\s*)*\(([^)]*)\)(?:(?:(?:\s*:\s*)*(\w*[^{;]*)))/;
+				return haxe_regex;
+			case "javascript":
+				return js_regex;
+			case "html":
+				return js_regex;
 			// TODO: other languages here.
 			default:
-				regex = ~/(?:function\s+\w+\s*)(?:<[\s\S]+>\s*)*\(([^)]*)\)(?:(?:(?:\s*:\s*)*(\w*[^{;]*)))/;
+				return haxe_regex;
 		}	
-		return regex;
 	}
 
 	/**


### PR DESCRIPTION
There isn't really a great vs code extension that allows for inline jsDocs creation on .js and .vue files. After adding in some additional document types and regex function parsing, this can now be done with codedox. 