### PR TITLE
Switch to Lix and use a development build of Haxe.

### DIFF
--- a/.haxerc
+++ b/.haxerc
@@ -1,0 +1,4 @@
+{
+  "version": "a8f2911",
+  "resolveLibs": "scoped"
+}

--- a/haxe_libraries/hxnodejs.hxml
+++ b/haxe_libraries/hxnodejs.hxml
@@ -1,0 +1,7 @@
+# @install: lix --silent download "haxelib:/hxnodejs#12.1.0" into hxnodejs/12.1.0/haxelib
+-cp ${HAXE_LIBCACHE}/hxnodejs/12.1.0/haxelib/src
+-D hxnodejs=12.1.0
+--macro allowPackage('sys')
+# should behave like other target defines and not be defined in macro context
+--macro define('nodejs')
+--macro _internal.SuppressDeprecated.run()

--- a/haxe_libraries/vscode.hxml
+++ b/haxe_libraries/vscode.hxml
@@ -1,0 +1,4 @@
+# @install: lix --silent download "haxelib:/vscode#1.59.0" into vscode/1.59.0/haxelib
+-lib hxnodejs
+-cp ${HAXE_LIBCACHE}/vscode/1.59.0/haxelib/src
+-D vscode=1.59.0


### PR DESCRIPTION
This is [the same Haxe version used by vshaxe](https://github.com/vshaxe/vshaxe/blob/master/.haxerc#L2), which fixes vshaxe/vshaxe#534.