### PR TITLE
Use ES6.

### DIFF
--- a/build-release.hxml
+++ b/build-release.hxml
@@ -1,4 +1,5 @@
 -cp src
 -lib vscode
 -js out/codedox.js
+-D js-es=6
 wiggin.codedox.CodeDox

--- a/build.hxml
+++ b/build.hxml
@@ -2,4 +2,5 @@
 -lib vscode
 -debug
 -js out/codedox.js
+-D js-es=6
 wiggin.codedox.CodeDox


### PR DESCRIPTION
Turns out Codedox is broken right now, adding `-D js-es=6` seems to fix it.